### PR TITLE
Fix shell injection in executePython and executeBatch

Switch from shell string interpolation to execFile with argv arrays so
arguments with spaces, quotes, or metacharacters are passed safely.

- executePython: use execFileAsync(pythonCmd, [scriptPath, ...args])
  instead of building a shell command string with args.join(' ').
  ENOENT is now the probe signal for "interpreter not found", so the
  loop only continues on a missing binary, not on script errors.
- executeBatch: use execFileAsync('cmd', ['/c', script, ...args]) on
  Windows and execFileAsync('/bin/sh', [script, ...args]) on POSIX.
  Replaces hardcoded bash with /bin/sh for maximum portability.

Addresses Sourcery review comments.



### DIFF
--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -3,13 +3,14 @@
  * Cross-platform: works on Windows, Linux, and macOS.
  */
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { join } from 'path';
 import { access } from 'fs/promises';
 import type { ExecOptions, ExecResult } from '../types/index.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Execute a command with timeout and error handling
@@ -50,7 +51,8 @@ export async function executeCommand(
 }
 
 /**
- * Execute a Python script
+ * Execute a Python script.
+ * Uses execFile with an argv array to avoid shell interpolation of args.
  */
 export async function executePython(
   scriptPath: string,
@@ -60,18 +62,40 @@ export async function executePython(
   // Try python3 first, then python, then py (Windows launcher)
   const pythonCommands = ['python3', 'python', 'py'];
 
+  const execOpts = {
+    cwd: options.cwd ?? process.cwd(),
+    timeout: options.timeout ?? 120000,
+    env: { ...(options.env ?? process.env) } as Record<string, string>,
+    maxBuffer: 10 * 1024 * 1024,
+    windowsHide: true
+  };
+
   for (const pythonCmd of pythonCommands) {
     try {
-      const checkResult = await executeCommand(`${pythonCmd} --version`, {
-        timeout: 5000
-      });
+      // Probe availability without shell interpolation
+      await execFileAsync(pythonCmd, ['--version'], { timeout: 5000 });
 
-      if (checkResult.success) {
-        const command = `${pythonCmd} "${scriptPath}" ${args.join(' ')}`;
-        return await executeCommand(command, options);
-      }
-    } catch {
-      continue;
+      const { stdout, stderr } = await execFileAsync(
+        pythonCmd,
+        [scriptPath, ...args],
+        execOpts
+      );
+      return {
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode: 0,
+        success: true
+      };
+    } catch (error: any) {
+      // If the error is "not found", try the next candidate
+      if (error.code === 'ENOENT') continue;
+      // Script ran but exited non-zero — return the output, stop trying
+      return {
+        stdout: error.stdout?.trim() || '',
+        stderr: error.stderr?.trim() || error.message,
+        exitCode: error.code ?? 1,
+        success: false
+      };
     }
   }
 
@@ -84,18 +108,44 @@ export async function executePython(
 }
 
 /**
- * Execute a batch file (Windows) or shell script (Linux/macOS)
+ * Execute a batch file (Windows) or shell script (Linux/macOS).
+ * Uses execFile with an argv array — no shell interpolation of args.
+ * Uses /bin/sh on POSIX for maximum portability (no bash dependency).
  */
 export async function executeBatch(
   scriptPath: string,
   args: string[] = [],
   options: ExecOptions = {}
 ): Promise<ExecResult> {
-  const isWindows = process.platform === 'win32';
-  const command = isWindows
-    ? `cmd /c "${scriptPath}" ${args.join(' ')}`
-    : `bash "${scriptPath}" ${args.join(' ')}`;
-  return await executeCommand(command, options);
+  const execOpts = {
+    cwd: options.cwd ?? process.cwd(),
+    timeout: options.timeout ?? 120000,
+    env: { ...(options.env ?? process.env) } as Record<string, string>,
+    maxBuffer: 10 * 1024 * 1024,
+    windowsHide: true
+  };
+
+  try {
+    const isWindows = process.platform === 'win32';
+    const [interpreter, interpArgs] = isWindows
+      ? ['cmd', ['/c', scriptPath, ...args]]
+      : ['/bin/sh', [scriptPath, ...args]];
+
+    const { stdout, stderr } = await execFileAsync(interpreter, interpArgs, execOpts);
+    return {
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      exitCode: 0,
+      success: true
+    };
+  } catch (error: any) {
+    return {
+      stdout: error.stdout?.trim() || '',
+      stderr: error.stderr?.trim() || error.message,
+      exitCode: error.code ?? 1,
+      success: false
+    };
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

Prevent shell injection vulnerabilities in script execution utilities by switching to argv-based execFile calls and standardizing interpreter handling.

Bug Fixes:
- Eliminate shell injection risk in executePython by avoiding shell command string construction and using execFile with argument arrays.
- Eliminate shell injection risk in executeBatch by executing scripts via cmd or /bin/sh with argv arrays instead of interpolated shell strings.

Enhancements:
- Unify and harden process execution options (cwd, timeout, env, maxBuffer, windowsHide) for Python and batch/script runners.
- Change Python interpreter probing to rely on ENOENT for missing binaries and stop falling back on script errors.
- Use /bin/sh instead of bash for POSIX batch/script execution to improve portability.