### PR TITLE
Add 7 new tools and bump to v1.1.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,10 +2,10 @@
 
 ## What this repo is
 
-MCP server that exposes 14 ESP32 development tools to Claude via the Model Context Protocol.
+MCP server that exposes 21 ESP32 development tools to Claude via the Model Context Protocol.
 It wraps FirmwareToolkit and PlatformIO for build / flash / test / benchmark operations.
 
-## MCP tools reference (14 tools)
+## MCP tools reference (21 tools)
 
 ### Serial port management
 - `esp32_list_ports` — list all ports with detection status and favorites
@@ -28,6 +28,19 @@ It wraps FirmwareToolkit and PlatformIO for build / flash / test / benchmark ope
 ### Firmware testing
 - `esp32_test_firmware(port?, baudRate?)` — boot / heartbeat / memory tests
 - `esp32_validate_deployment(port?)` — readiness assessment with issues/warnings
+
+### Project lifecycle
+- `esp32_create_project(name, projectPath?, board?, template?)` — scaffold a new PlatformIO project
+- `esp32_validate_project(projectPath?)` — check project structure and platformio.ini
+- `esp32_list_libraries(query?, installed?)` — search registry or list installed libraries
+- `esp32_run_tests(projectPath?, environment?, filter?)` — run PlatformIO unit tests
+
+### Log analysis
+- `esp32_parse_logs(logPath)` — parse serial log file into structured entries with panic detection
+
+### OTA & network
+- `esp32_generate_ota_image(projectPath?, environment?, outputPath?)` — package firmware.bin with MD5/SHA-256
+- `esp32_list_network_devices(timeout?)` — discover ESP32s via mDNS (avahi/dns-sd) with ARP fallback
 
 ## Environment variables
 - `FIRMWARE_TOOLKIT_PATH` — path to FirmwareToolkit clone (required for benchmark/test tools)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midas/esp32-devops-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for ESP32 development with build automation, serial port management, and performance testing",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ import * as serialTools from './tools/serial.js';
 import * as buildTools from './tools/build.js';
 import * as benchmarkTools from './tools/benchmark.js';
 import * as testTools from './tools/test.js';
+import * as projectTools from './tools/project.js';
+import * as logTools from './tools/logs.js';
+import * as otaTools from './tools/ota.js';
 
 /**
  * MCP Server instance
@@ -27,7 +30,7 @@ import * as testTools from './tools/test.js';
 const server = new Server(
   {
     name: 'esp32-devops-mcp',
-    version: '1.0.0',
+    version: '1.1.0',
   },
   {
     capabilities: {
@@ -224,6 +227,147 @@ const tools = [
           type: 'number',
           description: 'Test duration in seconds (default: 300)',
           default: 300,
+        },
+      },
+      required: [],
+    },
+  },
+
+  // Project Lifecycle Tools
+  {
+    name: 'esp32_create_project',
+    description: 'Scaffold a new PlatformIO ESP32 project with a starter template',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Project name (letters, numbers, underscores, hyphens)',
+        },
+        projectPath: {
+          type: 'string',
+          description: 'Parent directory for the new project (optional, defaults to cwd)',
+        },
+        board: {
+          type: 'string',
+          description: 'PlatformIO board ID (default: esp32dev)',
+          default: 'esp32dev',
+        },
+        template: {
+          type: 'string',
+          description: 'Starter template: bare | wifi | ble | mqtt (default: bare)',
+          enum: ['bare', 'wifi', 'ble', 'mqtt'],
+          default: 'bare',
+        },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'esp32_validate_project',
+    description: 'Validate a PlatformIO project structure and report missing files or misconfigurations',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Path to PlatformIO project (optional, uses cwd)',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'esp32_list_libraries',
+    description: 'Search the PlatformIO library registry or list installed libraries',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Search term (optional)',
+        },
+        installed: {
+          type: 'boolean',
+          description: 'List installed libraries instead of searching registry (default: false)',
+          default: false,
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'esp32_run_tests',
+    description: 'Run PlatformIO unit tests and return structured pass/fail results',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Path to PlatformIO project (optional)',
+        },
+        environment: {
+          type: 'string',
+          description: 'PlatformIO environment to test (optional)',
+        },
+        filter: {
+          type: 'string',
+          description: 'Test name filter pattern (optional, e.g. "test_sensor*")',
+        },
+      },
+      required: [],
+    },
+  },
+
+  // Log Analysis Tools
+  {
+    name: 'esp32_parse_logs',
+    description: 'Parse a saved ESP32 serial log file into structured entries with severity, tag, timestamp, and panic detection',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        logPath: {
+          type: 'string',
+          description: 'Absolute or relative path to the log file',
+        },
+      },
+      required: ['logPath'],
+    },
+  },
+
+  // OTA & Network Tools
+  {
+    name: 'esp32_generate_ota_image',
+    description: 'Package the built firmware.bin for OTA deployment — returns path, size, MD5, and SHA-256',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Path to PlatformIO project (optional)',
+        },
+        environment: {
+          type: 'string',
+          description: 'PlatformIO environment whose firmware to package (optional, auto-detected)',
+        },
+        outputPath: {
+          type: 'string',
+          description: 'Directory to copy the OTA image into (optional)',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'esp32_list_network_devices',
+    description: 'Discover ESP32 devices on the local network via mDNS (avahi/dns-sd) with ARP fallback',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        timeout: {
+          type: 'number',
+          description: 'Discovery timeout in milliseconds (default: 5000)',
+          default: 5000,
         },
       },
       required: [],
@@ -482,6 +626,60 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       };
     }
 
+      // Project Lifecycle Tools
+    if (name === 'esp32_create_project') {
+      const result = await projectTools.createProject(
+        args.name as string,
+        args.projectPath as string | undefined,
+        args.board as string | undefined,
+        args.template as string | undefined
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
+    if (name === 'esp32_validate_project') {
+      const result = await projectTools.validateProject(args.projectPath as string | undefined);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
+    if (name === 'esp32_list_libraries') {
+      const result = await projectTools.listLibraries(
+        args.query as string | undefined,
+        args.installed as boolean | undefined
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
+    if (name === 'esp32_run_tests') {
+      const result = await projectTools.runPlatformIOTests(
+        args.projectPath as string | undefined,
+        args.environment as string | undefined,
+        args.filter as string | undefined
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
+    // Log Analysis Tools
+    if (name === 'esp32_parse_logs') {
+      const result = await logTools.parseSerialLogs(args.logPath as string);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
+    // OTA & Network Tools
+    if (name === 'esp32_generate_ota_image') {
+      const result = await otaTools.generateOTAImage(
+        args.projectPath as string | undefined,
+        args.environment as string | undefined,
+        args.outputPath as string | undefined
+      );
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
+    if (name === 'esp32_list_network_devices') {
+      const result = await otaTools.listNetworkDevices(args.timeout as number | undefined);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
     // Unknown tool
     throw new Error(`Unknown tool: ${name}`);
 
@@ -509,7 +707,7 @@ async function main() {
   await server.connect(transport);
 
   console.error('ESP32 DevOps MCP Server started');
-  console.error('Version: 1.0.0');
+  console.error('Version: 1.1.0');
   console.error('Toolkit path:', process.env.FIRMWARE_TOOLKIT_PATH || '[NOT SET - required for benchmarking/testing features]');
 }
 

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -1,0 +1,134 @@
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import { fileExists } from '../utils/exec.js';
+import type { LogEntry, ParsedLogReport } from '../types/index.js';
+
+// ESP-IDF log format: E (12345) TAG: message
+const LOG_LINE = /^([EWIDV])\s+\((\d+)\)\s+([^:]+):\s*(.+)$/;
+// Arduino-style log prefixes
+const ARDUINO_LOG = /^\[(ERROR|WARN|INFO|DEBUG|VERBOSE)\]\s*(.+)$/i;
+// Guru Meditation / abort / panic
+const PANIC_PATTERNS = [
+  /Guru Meditation Error/i,
+  /abort\(\) was called/i,
+  /Backtrace:/i,
+  /LoadProhibited/i,
+  /StoreProhibited/i,
+  /rst:0x[0-9a-f]+\s*\(PANIC\)/i,
+];
+// Free heap reports
+const HEAP_PATTERN = /[Ff]ree\s+[Hh]eap[:\s]+(\d+)/;
+
+const LEVEL_MAP: Record<string, LogEntry['level']> = {
+  E: 'ERROR',
+  W: 'WARN',
+  I: 'INFO',
+  D: 'DEBUG',
+  V: 'VERBOSE',
+  ERROR: 'ERROR',
+  WARN: 'WARN',
+  INFO: 'INFO',
+  DEBUG: 'DEBUG',
+  VERBOSE: 'VERBOSE',
+};
+
+export async function parseSerialLogs(logPath: string): Promise<ParsedLogReport> {
+  const absPath = resolve(logPath);
+
+  if (!await fileExists(absPath)) {
+    return {
+      success: false,
+      logPath: absPath,
+      totalLines: 0,
+      entries: [],
+      summary: { errors: 0, warnings: 0, panics: 0 },
+      panics: [],
+      error: `Log file not found: ${absPath}`,
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = await readFile(absPath, 'utf8');
+  } catch (err: any) {
+    return {
+      success: false,
+      logPath: absPath,
+      totalLines: 0,
+      entries: [],
+      summary: { errors: 0, warnings: 0, panics: 0 },
+      panics: [],
+      error: `Cannot read log file: ${err.message}`,
+    };
+  }
+
+  const lines = raw.split('\n');
+  const entries: LogEntry[] = [];
+  const panics: string[] = [];
+  let heapMin: number | undefined;
+  let heapMax: number | undefined;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trimEnd();
+    if (!line) continue;
+
+    // Check for panics / crashes
+    for (const pat of PANIC_PATTERNS) {
+      if (pat.test(line)) {
+        panics.push(line);
+        break;
+      }
+    }
+
+    // Track heap values
+    const heapMatch = line.match(HEAP_PATTERN);
+    if (heapMatch) {
+      const val = parseInt(heapMatch[1]);
+      if (heapMin === undefined || val < heapMin) heapMin = val;
+      if (heapMax === undefined || val > heapMax) heapMax = val;
+    }
+
+    // Parse log level
+    const espMatch = line.match(LOG_LINE);
+    if (espMatch) {
+      entries.push({
+        level: LEVEL_MAP[espMatch[1]] ?? 'UNKNOWN',
+        timestamp: parseInt(espMatch[2]),
+        tag: espMatch[3].trim(),
+        message: espMatch[4].trim(),
+        lineNumber: i + 1,
+      });
+      continue;
+    }
+
+    const arduinoMatch = line.match(ARDUINO_LOG);
+    if (arduinoMatch) {
+      entries.push({
+        level: LEVEL_MAP[arduinoMatch[1].toUpperCase()] ?? 'UNKNOWN',
+        message: arduinoMatch[2].trim(),
+        lineNumber: i + 1,
+      });
+      continue;
+    }
+
+    // Unclassified non-empty line
+    entries.push({ level: 'UNKNOWN', message: line, lineNumber: i + 1 });
+  }
+
+  const summary = {
+    errors: entries.filter(e => e.level === 'ERROR').length,
+    warnings: entries.filter(e => e.level === 'WARN').length,
+    panics: panics.length,
+    ...(heapMin !== undefined ? { heapMin } : {}),
+    ...(heapMax !== undefined ? { heapMax } : {}),
+  };
+
+  return {
+    success: true,
+    logPath: absPath,
+    totalLines: lines.length,
+    entries,
+    summary,
+    panics,
+  };
+}

--- a/src/tools/ota.ts
+++ b/src/tools/ota.ts
@@ -1,0 +1,167 @@
+import { createHash } from 'crypto';
+import { readFile, stat, copyFile, mkdir, readdir } from 'fs/promises';
+import { join, resolve } from 'path';
+import { fileExists, executeCommand } from '../utils/exec.js';
+import { validateProjectPath, validateEnvironment, sanitizePath } from '../utils/validation.js';
+import type { OTAImageResult, NetworkScanResult, NetworkDevice } from '../types/index.js';
+
+export async function generateOTAImage(
+  projectPath?: string,
+  environment?: string,
+  outputPath?: string
+): Promise<OTAImageResult> {
+  if (projectPath && !validateProjectPath(projectPath)) {
+    return { success: false, readyForDeploy: false, error: 'Invalid project path' };
+  }
+  if (environment && !validateEnvironment(environment)) {
+    return { success: false, readyForDeploy: false, error: 'Invalid environment name' };
+  }
+
+  const dir = projectPath ? resolve(projectPath) : process.cwd();
+  const buildDir = join(dir, '.pio', 'build');
+
+  let firmwarePath: string | null = null;
+  let detectedEnv = environment;
+
+  if (environment) {
+    const candidate = join(buildDir, environment, 'firmware.bin');
+    if (await fileExists(candidate)) {
+      firmwarePath = candidate;
+    }
+  } else {
+    try {
+      const envDirs = await readdir(buildDir);
+      for (const envDir of envDirs) {
+        const candidate = join(buildDir, envDir, 'firmware.bin');
+        if (await fileExists(candidate)) {
+          firmwarePath = candidate;
+          detectedEnv = envDir;
+          break;
+        }
+      }
+    } catch {
+      // .pio/build does not exist yet
+    }
+  }
+
+  if (!firmwarePath) {
+    return {
+      success: false,
+      readyForDeploy: false,
+      environment: detectedEnv,
+      error: 'firmware.bin not found in .pio/build/. Run esp32_build first.',
+    };
+  }
+
+  const [fileData, fileStat] = await Promise.all([
+    readFile(firmwarePath),
+    stat(firmwarePath),
+  ]);
+
+  const md5    = createHash('md5').update(fileData).digest('hex');
+  const sha256 = createHash('sha256').update(fileData).digest('hex');
+
+  let finalPath = firmwarePath;
+  if (outputPath) {
+    const outDir = resolve(outputPath);
+    await mkdir(outDir, { recursive: true });
+    finalPath = join(outDir, `firmware_${detectedEnv}_${Date.now()}.bin`);
+    await copyFile(firmwarePath, finalPath);
+  }
+
+  return {
+    success: true,
+    imagePath: finalPath,
+    firmwareSize: fileStat.size,
+    md5,
+    sha256,
+    environment: detectedEnv,
+    readyForDeploy: true,
+  };
+}
+
+export async function listNetworkDevices(timeoutMs: number = 5000): Promise<NetworkScanResult> {
+  const platform = process.platform;
+
+  if (platform === 'linux') {
+    return scanLinux(timeoutMs);
+  } else if (platform === 'darwin') {
+    return scanMacOS(timeoutMs);
+  } else {
+    return scanARP('arp');
+  }
+}
+
+async function scanLinux(timeoutMs: number): Promise<NetworkScanResult> {
+  const secs = Math.max(2, Math.floor(timeoutMs / 1000));
+  const result = await executeCommand(
+    `avahi-browse -t -p -r _arduino._tcp 2>/dev/null; avahi-browse -t -p -r _http._tcp 2>/dev/null`,
+    { timeout: timeoutMs + 2000 }
+  );
+  if (result.stdout.trim()) {
+    return { success: true, devices: parseAvahi(result.stdout), method: 'avahi-browse' };
+  }
+  // avahi not available — fall back
+  return scanARP('arp -n');
+}
+
+async function scanMacOS(timeoutMs: number): Promise<NetworkScanResult> {
+  const secs = Math.max(2, Math.floor(timeoutMs / 1000));
+  const result = await executeCommand(
+    `dns-sd -B _arduino._tcp local`,
+    { timeout: timeoutMs }
+  );
+  if (result.stdout.trim()) {
+    return { success: true, devices: parseDNSSD(result.stdout), method: 'dns-sd' };
+  }
+  return scanARP('arp -a');
+}
+
+async function scanARP(cmd: string): Promise<NetworkScanResult> {
+  const result = await executeCommand(cmd, { timeout: 5000 });
+  return {
+    success: result.success,
+    devices: parseARP(result.stdout),
+    method: 'arp-table',
+    note: 'ARP fallback: all LAN hosts shown — ESP32s are not distinguished. Use avahi/dns-sd for mDNS-aware discovery.',
+  };
+}
+
+function parseAvahi(output: string): NetworkDevice[] {
+  const devices: NetworkDevice[] = [];
+  for (const line of output.split('\n')) {
+    if (!line.startsWith('=')) continue;
+    const parts = line.split(';');
+    if (parts.length >= 9) {
+      devices.push({
+        hostname: parts[6]?.replace(/\.$/, '') ?? '',
+        ip:       parts[7],
+        port:     parseInt(parts[8]) || undefined,
+        service:  parts[4],
+      });
+    }
+  }
+  return devices;
+}
+
+function parseDNSSD(output: string): NetworkDevice[] {
+  const devices: NetworkDevice[] = [];
+  for (const line of output.split('\n')) {
+    const match = line.match(/\d+\s+\d+\s+\S+\s+(\S+)\s+(.+)/);
+    if (match) {
+      devices.push({ hostname: match[2].trim(), service: match[1] });
+    }
+  }
+  return devices;
+}
+
+function parseARP(output: string): NetworkDevice[] {
+  const devices: NetworkDevice[] = [];
+  for (const line of output.split('\n')) {
+    const match = line.match(/\((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\)/);
+    if (match) {
+      devices.push({ hostname: match[1], ip: match[1] });
+    }
+  }
+  return devices;
+}

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -1,0 +1,348 @@
+import { executeCommand, fileExists } from '../utils/exec.js';
+import { validateProjectPath, validateEnvironment, sanitizePath } from '../utils/validation.js';
+import { readFile, readdir, writeFile } from 'fs/promises';
+import { join, resolve } from 'path';
+import type {
+  ProjectCreationResult,
+  ValidationResult,
+  LibraryInfo,
+  TestRunResult,
+  TestSuiteResult,
+  TestCase,
+} from '../types/index.js';
+
+const TEMPLATES: Record<string, string> = {
+  bare: `#include <Arduino.h>
+
+void setup() {
+  Serial.begin(115200);
+}
+
+void loop() {
+}
+`,
+  wifi: `#include <Arduino.h>
+#include <WiFi.h>
+
+const char* SSID     = "your_ssid";
+const char* PASSWORD = "your_password";
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("\\nConnected: " + WiFi.localIP().toString());
+}
+
+void loop() {
+  delay(1000);
+}
+`,
+  ble: `#include <Arduino.h>
+#include <BLEDevice.h>
+#include <BLEServer.h>
+#include <BLEUtils.h>
+#include <BLE2902.h>
+
+void setup() {
+  Serial.begin(115200);
+  BLEDevice::init("ESP32-BLE");
+  BLEServer* server = BLEDevice::createServer();
+  BLEDevice::startAdvertising();
+  Serial.println("BLE advertising started");
+}
+
+void loop() {
+  delay(1000);
+}
+`,
+  mqtt: `#include <Arduino.h>
+#include <WiFi.h>
+#include <PubSubClient.h>
+
+const char* SSID        = "your_ssid";
+const char* PASSWORD    = "your_password";
+const char* MQTT_BROKER = "broker.example.com";
+
+WiFiClient   wifiClient;
+PubSubClient mqtt(wifiClient);
+
+void callback(char* topic, byte* payload, unsigned int length) {
+  Serial.printf("Message [%s]: %.*s\\n", topic, length, payload);
+}
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(SSID, PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) delay(500);
+  mqtt.setServer(MQTT_BROKER, 1883);
+  mqtt.setCallback(callback);
+}
+
+void loop() {
+  if (!mqtt.connected()) {
+    mqtt.connect("ESP32Client");
+  }
+  mqtt.loop();
+  delay(100);
+}
+`,
+};
+
+export async function createProject(
+  name: string,
+  projectPath?: string,
+  board: string = 'esp32dev',
+  template: string = 'bare'
+): Promise<ProjectCreationResult> {
+  if (!name || !/^[a-zA-Z0-9_-]+$/.test(name)) {
+    return {
+      success: false,
+      projectPath: '',
+      board,
+      template,
+      error: 'Invalid project name: use only letters, numbers, underscores, and hyphens',
+    };
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(board)) {
+    return { success: false, projectPath: '', board, template, error: 'Invalid board identifier' };
+  }
+
+  const baseDir = projectPath ? resolve(projectPath) : process.cwd();
+  const dir = join(baseDir, name);
+
+  const result = await executeCommand(
+    `pio project init --project-dir "${dir}" --board ${board}`,
+    { timeout: 60000 }
+  );
+
+  if (!result.success) {
+    return {
+      success: false,
+      projectPath: dir,
+      board,
+      template,
+      error: result.stderr || 'pio project init failed',
+      exitCode: result.exitCode,
+    };
+  }
+
+  const starter = TEMPLATES[template] ?? TEMPLATES.bare;
+  try {
+    await writeFile(join(dir, 'src', 'main.cpp'), starter, 'utf8');
+  } catch {
+    // Non-fatal — project scaffolded but template write failed
+  }
+
+  return { success: true, projectPath: dir, board, template };
+}
+
+export async function validateProject(projectPath?: string): Promise<ValidationResult> {
+  const dir = projectPath ? resolve(projectPath) : process.cwd();
+
+  if (projectPath && !validateProjectPath(projectPath)) {
+    return {
+      success: false,
+      valid: false,
+      projectPath: dir,
+      issues: [{ severity: 'error', message: 'Invalid project path' }],
+    };
+  }
+
+  const issues: { severity: 'error' | 'warning'; message: string }[] = [];
+
+  const iniPath = join(dir, 'platformio.ini');
+  if (!await fileExists(iniPath)) {
+    return {
+      success: true,
+      valid: false,
+      projectPath: dir,
+      issues: [{ severity: 'error', message: 'platformio.ini not found — not a PlatformIO project' }],
+    };
+  }
+
+  let iniContent = '';
+  try {
+    iniContent = await readFile(iniPath, 'utf8');
+  } catch {
+    return {
+      success: true,
+      valid: false,
+      projectPath: dir,
+      issues: [{ severity: 'error', message: 'Cannot read platformio.ini' }],
+    };
+  }
+
+  const envMatches = [...iniContent.matchAll(/^\[env:([^\]]+)\]/gm)].map(m => m[1]);
+  const boardMatch = iniContent.match(/^board\s*=\s*(.+)$/m);
+  const frameworkMatch = iniContent.match(/^framework\s*=\s*(.+)$/m);
+
+  if (envMatches.length === 0) {
+    issues.push({ severity: 'warning', message: 'No [env:*] sections found in platformio.ini' });
+  }
+  if (!boardMatch) {
+    issues.push({ severity: 'warning', message: 'No board configured in platformio.ini' });
+  }
+  if (!frameworkMatch) {
+    issues.push({ severity: 'warning', message: 'No framework configured in platformio.ini' });
+  }
+
+  let srcEntries: string[] = [];
+  try {
+    srcEntries = await readdir(join(dir, 'src'));
+  } catch {
+    issues.push({ severity: 'error', message: 'src/ directory not found' });
+  }
+
+  if (srcEntries.length > 0 && !srcEntries.some(f => /\.(cpp|c|ino)$/.test(f))) {
+    issues.push({ severity: 'warning', message: 'No source files (.cpp/.c/.ino) found in src/' });
+  }
+
+  return {
+    success: true,
+    valid: issues.filter(i => i.severity === 'error').length === 0,
+    projectPath: dir,
+    issues,
+    config: {
+      environments: envMatches,
+      boards: boardMatch ? [boardMatch[1].trim()] : [],
+      framework: frameworkMatch ? frameworkMatch[1].trim() : '',
+    },
+  };
+}
+
+export async function listLibraries(
+  query?: string,
+  installed: boolean = false
+): Promise<{ success: boolean; libraries: LibraryInfo[]; count: number; error?: string; exitCode?: number }> {
+  const safeQuery = query ? query.replace(/['"\\]/g, '') : '';
+  const cmd = installed
+    ? 'pio lib list --json-output'
+    : safeQuery
+      ? `pio lib search "${safeQuery}" --json-output`
+      : 'pio lib list --json-output';
+
+  const result = await executeCommand(cmd, { timeout: 30000 });
+
+  if (!result.success) {
+    return {
+      success: false,
+      libraries: [],
+      count: 0,
+      error: result.stderr || 'pio lib command failed',
+      exitCode: result.exitCode,
+    };
+  }
+
+  try {
+    const data = JSON.parse(result.stdout);
+    const raw: any[] = Array.isArray(data) ? data : (data.items ?? []);
+    const libraries: LibraryInfo[] = raw.map(lib => ({
+      id: lib.id,
+      name: lib.name,
+      description: lib.description,
+      version: lib.version?.name ?? lib.version,
+      author: Array.isArray(lib.authors)
+        ? lib.authors.map((a: any) => a.name ?? a).join(', ')
+        : lib.authors,
+      keywords: lib.keywords,
+    }));
+    return { success: true, libraries, count: libraries.length };
+  } catch {
+    return {
+      success: true,
+      libraries: [{ name: 'raw', description: result.stdout }],
+      count: 0,
+    };
+  }
+}
+
+export async function runPlatformIOTests(
+  projectPath?: string,
+  environment?: string,
+  filter?: string
+): Promise<TestRunResult> {
+  if (projectPath && !validateProjectPath(projectPath)) {
+    return { success: false, output: '', suites: [], totalPassed: 0, totalFailed: 0, error: 'Invalid project path' };
+  }
+  if (environment && !validateEnvironment(environment)) {
+    return { success: false, output: '', suites: [], totalPassed: 0, totalFailed: 0, error: 'Invalid environment name' };
+  }
+  if (filter && !/^[a-zA-Z0-9_*/-]+$/.test(filter)) {
+    return { success: false, output: '', suites: [], totalPassed: 0, totalFailed: 0, error: 'Invalid filter pattern' };
+  }
+
+  const parts = ['pio test'];
+  if (projectPath) parts.push(`--project-dir "${sanitizePath(projectPath)}"`);
+  if (environment) parts.push(`-e ${environment}`);
+  if (filter) parts.push(`-f ${filter}`);
+
+  const result = await executeCommand(parts.join(' '), {
+    cwd: projectPath ? resolve(projectPath) : process.cwd(),
+    timeout: 300000,
+  });
+
+  const suites = parseTestOutput(result.stdout + result.stderr);
+  const totalPassed = suites.reduce((s, t) => s + t.passed, 0);
+  const totalFailed = suites.reduce((s, t) => s + t.failed, 0);
+
+  return {
+    success: result.success && totalFailed === 0,
+    output: result.stdout,
+    suites,
+    totalPassed,
+    totalFailed,
+    exitCode: result.exitCode,
+    ...(result.success ? {} : { error: result.stderr }),
+  };
+}
+
+function parseTestOutput(output: string): TestSuiteResult[] {
+  const suites: TestSuiteResult[] = [];
+  let current: TestSuiteResult | null = null;
+
+  for (const line of output.split('\n')) {
+    // New environment block
+    const envMatch = line.match(/(?:ENVIRONMENT|Running tests? in environment[:\s]+)[`']?([a-zA-Z0-9_-]+)[`']?/i);
+    if (envMatch) {
+      if (current) suites.push(current);
+      current = { environment: envMatch[1], passed: 0, failed: 0, ignored: 0, duration: 0, tests: [] };
+      continue;
+    }
+
+    if (!current) {
+      current = { environment: 'default', passed: 0, failed: 0, ignored: 0, duration: 0, tests: [] };
+    }
+
+    // Unity test result line: path:line:name:STATUS[:message]
+    const unityMatch = line.match(/^[^:]+:\d+:([^:]+):(PASS|FAIL|IGNORE)(?::(.+))?$/);
+    if (unityMatch) {
+      const status: TestCase['status'] =
+        unityMatch[2] === 'PASS' ? 'PASSED' : unityMatch[2] === 'FAIL' ? 'FAILED' : 'IGNORED';
+      current.tests.push({ name: unityMatch[1].trim(), status, message: unityMatch[3] });
+      if (status === 'PASSED') current.passed++;
+      else if (status === 'FAILED') current.failed++;
+      else current.ignored++;
+      continue;
+    }
+
+    // Summary: "X Tests Y Failures Z Ignored"
+    const summaryMatch = line.match(/(\d+) Tests\s+(\d+) Failures\s+(\d+) Ignored/i);
+    if (summaryMatch) {
+      current.passed = parseInt(summaryMatch[1]) - parseInt(summaryMatch[2]) - parseInt(summaryMatch[3]);
+      current.failed = parseInt(summaryMatch[2]);
+      current.ignored = parseInt(summaryMatch[3]);
+      continue;
+    }
+
+    // Duration
+    const durationMatch = line.match(/Elapsed [Tt]ime:\s*([\d.]+)\s*s/);
+    if (durationMatch) current.duration = parseFloat(durationMatch[1]);
+  }
+
+  if (current) suites.push(current);
+  return suites;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,3 +80,115 @@ export interface ExecResult {
   exitCode: number;
   success: boolean;
 }
+
+export interface ProjectCreationResult {
+  success: boolean;
+  projectPath: string;
+  board: string;
+  template: string;
+  error?: string;
+  exitCode?: number;
+}
+
+export interface ValidationIssue {
+  severity: 'error' | 'warning';
+  message: string;
+}
+
+export interface ValidationResult {
+  success: boolean;
+  valid: boolean;
+  projectPath: string;
+  issues: ValidationIssue[];
+  config?: {
+    environments: string[];
+    boards: string[];
+    framework: string;
+  };
+  error?: string;
+}
+
+export interface LibraryInfo {
+  id?: number;
+  name: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  keywords?: string[];
+}
+
+export interface TestCase {
+  name: string;
+  status: 'PASSED' | 'FAILED' | 'IGNORED';
+  duration?: number;
+  message?: string;
+}
+
+export interface TestSuiteResult {
+  environment: string;
+  passed: number;
+  failed: number;
+  ignored: number;
+  duration: number;
+  tests: TestCase[];
+}
+
+export interface TestRunResult {
+  success: boolean;
+  output: string;
+  suites: TestSuiteResult[];
+  totalPassed: number;
+  totalFailed: number;
+  error?: string;
+  exitCode?: number;
+}
+
+export interface LogEntry {
+  level: 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'VERBOSE' | 'UNKNOWN';
+  timestamp?: number;
+  tag?: string;
+  message: string;
+  lineNumber: number;
+}
+
+export interface ParsedLogReport {
+  success: boolean;
+  logPath: string;
+  totalLines: number;
+  entries: LogEntry[];
+  summary: {
+    errors: number;
+    warnings: number;
+    panics: number;
+    heapMin?: number;
+    heapMax?: number;
+  };
+  panics: string[];
+  error?: string;
+}
+
+export interface OTAImageResult {
+  success: boolean;
+  imagePath?: string;
+  firmwareSize?: number;
+  md5?: string;
+  sha256?: string;
+  environment?: string;
+  readyForDeploy: boolean;
+  error?: string;
+}
+
+export interface NetworkDevice {
+  hostname: string;
+  ip?: string;
+  port?: number;
+  service?: string;
+}
+
+export interface NetworkScanResult {
+  success: boolean;
+  devices: NetworkDevice[];
+  method: string;
+  note?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary

Adds 7 new MCP tools covering the full ESP32 DevOps lifecycle, plus a version bump to 1.1.0.

### New tools

| Tool | What it does |
|---|---|
| `esp32_create_project` | Scaffold a PlatformIO project (`bare` / `wifi` / `ble` / `mqtt` templates) |
| `esp32_validate_project` | Check `platformio.ini`, `[env:]` sections, board, framework, and `src/` layout |
| `esp32_list_libraries` | Search PlatformIO registry or list installed libraries (JSON parsed) |
| `esp32_run_tests` | Run `pio test`, parse Unity output into per-suite pass/fail/ignored counts |
| `esp32_parse_logs` | Read a serial log file, classify lines (ESP-IDF E/W/I/D/V), extract panics, track heap min/max |
| `esp32_generate_ota_image` | Find `firmware.bin` in `.pio/build/`, return path + size + MD5 + SHA-256 |
| `esp32_list_network_devices` | mDNS scan via avahi-browse (Linux) / dns-sd (macOS) with ARP table fallback |

### New source files
- `src/tools/project.ts` — create, validate, list-libraries, run-tests
- `src/tools/logs.ts` — log parser
- `src/tools/ota.ts` — OTA image packaging + network discovery

### New types
`ProjectCreationResult`, `ValidationResult`, `LibraryInfo`, `TestRunResult`, `ParsedLogReport`, `OTAImageResult`, `NetworkScanResult`

## Test plan
- [ ] `esp32_create_project name=hello_world` — confirms `platformio.ini` + `src/main.cpp` created
- [ ] `esp32_validate_project` on a valid and an invalid project path
- [ ] `esp32_list_libraries query=WiFi` — returns library results
- [ ] `esp32_run_tests` on a project with Unity tests
- [ ] `esp32_parse_logs logPath=...` on a captured serial log
- [ ] `esp32_generate_ota_image` after a successful build
- [ ] `esp32_list_network_devices` on a LAN with ESP32 devices

---

## Summary by Sourcery

Add new ESP32 project lifecycle, log analysis, and OTA/network tools and bump the MCP server to version 1.1.0.

New Features:
- Introduce tools to scaffold and validate PlatformIO ESP32 projects, manage libraries, and run unit tests.
- Add a log parsing tool to convert ESP32 serial logs into structured reports with error, panic, and heap summaries.
- Add OTA packaging and network discovery tools for generating firmware images and finding ESP32 devices on the LAN.

Enhancements:
- Update server, package metadata, and internal documentation to reflect the expanded toolset and new 1.1.0 release.